### PR TITLE
Add pytest-cov and coverage helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test coverage
+
+test:
+	pytest
+
+coverage:
+	pytest --cov=hdt --cov-report html
+	@echo "HTML report saved to htmlcov/index.html"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ Human Digital Twin is an AI-powered platform designed to model and optimize huma
    git clone https://github.com/Oloff2005/Human_Digital_twin.git
 Install required Python packages:
 pip install -r requirements.txt
+
+### Running Tests
+1. Install additional testing tools:
+   ```bash
+   pip install pytest pytest-cov
+   ```
+2. Generate an HTML coverage report:
+   ```bash
+   make coverage
+   ```
+   The report will be saved to `htmlcov/index.html`.
+
 Usage
 
 Connect your wearable device to the app.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "uvicorn",
   "scipy",
   "pytest",
+  "pytest-cov",
   "pyyaml",
   "seaborn==0.13.2",
   "pandas"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ scipy
 pyyaml
 seaborn==0.13.2
 pandas
+pytest
+pytest-cov


### PR DESCRIPTION
## Summary
- add `pytest-cov` dependency
- document how to run coverage reports
- provide Makefile with convenient `coverage` target

## Testing
- `pytest -q`
- `make coverage` *(fails: unrecognized arguments --cov because pytest-cov isn't installed)*

------
https://chatgpt.com/codex/tasks/task_e_68622a9f76c48332b2124b43bcf2988a