### PR TITLE
Add type hints and mypy config

### DIFF
--- a/hdt/config_loader.py
+++ b/hdt/config_loader.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
 try:
     import yaml  # type: ignore
 except ModuleNotFoundError:  # pragma: no cover - optional dependency may be absent
     yaml = None
     
-def _parse_scalar(value: str):
+def _parse_scalar(value: str) -> Any:
     """Parse a YAML scalar into the appropriate Python type."""
     lower = value.lower()
     if lower in {"true", "false"}:
@@ -17,7 +21,7 @@ def _parse_scalar(value: str):
             return value
 
 
-def _simple_yaml_load(path: str):
+def _simple_yaml_load(path: str) -> Dict[str, Any]:
     """Very small YAML loader supporting the subset used in tests."""
     root: dict = {}
     stack = [(0, root)]  # (indent, container)
@@ -65,14 +69,14 @@ def _simple_yaml_load(path: str):
                     parent[key] = _parse_scalar(rest)
     return root
 
-def load_units_config(path: str):
+def load_units_config(path: str) -> Dict[str, Any]:
     """Load unit configuration YAML."""
     if yaml is not None:
         with open(path, "r", encoding="utf-8") as f:
             return yaml.safe_load(f)
     return _simple_yaml_load(path)
 
-def load_sim_params(path: str):
+def load_sim_params(path: str) -> Dict[str, Any]:
     """Load simulator parameter YAML."""
     if yaml is not None:
         with open(path, "r", encoding="utf-8") as f:

--- a/hdt/core/time_manager.py
+++ b/hdt/core/time_manager.py
@@ -1,21 +1,26 @@
+from __future__ import annotations
+
+from typing import Dict
+
+
 class TimeManager:
     """
     Manages simulation time in minutes, hours, and days.
     Useful for circadian modeling and time-based processes.
     """
 
-    def __init__(self, start_minute=0):
-        self.minute = start_minute
+    def __init__(self, start_minute: int = 0) -> None:
+        self.minute: int = start_minute
 
     @property
-    def hour(self):
+    def hour(self) -> int:
         return (self.minute // 60) % 24
 
     @property
-    def day(self):
+    def day(self) -> int:
         return self.minute // (60 * 24)
 
-    def tick(self, step_minutes=60):
+    def tick(self, step_minutes: int = 60) -> None:
         """
         Advance time by a given step.
 
@@ -24,12 +29,12 @@ class TimeManager:
         """
         self.minute += step_minutes
 
-    def reset(self):
+    def reset(self) -> None:
         self.minute = 0
 
-    def get_time_state(self):
+    def get_time_state(self) -> Dict[str, int]:
         return {
             "minute": self.minute,
             "hour": self.hour,
-            "day": self.day
+            "day": self.day,
         }

--- a/hdt/engine/run_simulator.py
+++ b/hdt/engine/run_simulator.py
@@ -1,10 +1,18 @@
+from __future__ import annotations
+
 import json
+from typing import Any, Dict, List
 from hdt.engine.simulator import Simulator
 from hdt.config_loader import load_units_config, load_sim_params
 from hdt.inputs.input_parser import InputParser
 from hdt.inputs.signal_normalizer import SignalNormalizer
 
-def run_simulator(config_path, input_path, steps=1, verbose=False):
+def run_simulator(
+    config_path: str,
+    input_path: str,
+    steps: int = 1,
+    verbose: bool = False,
+) -> List[Dict[str, Any]]:
     """
     Loads config and inputs, initializes Simulator, and runs simulation.
 

--- a/hdt/engine/solver.py
+++ b/hdt/engine/solver.py
@@ -1,4 +1,6 @@
-from typing import List, Dict, Tuple
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
 
 # Avoid heavy third party dependencies like numpy/scipy so that the test suite
 # can run in a minimal environment.  The solver below implements a very simple
@@ -12,7 +14,7 @@ class ODESolver:
     a forward Euler integration across the provided ``t_eval`` grid.
     """
 
-    def __init__(self, units: List):
+    def __init__(self, units: List[Any]):
         """
         Initialize with a list of unit operations.
         Each unit must have:
@@ -20,12 +22,12 @@ class ODESolver:
         - set_state(state_dict)
         - derivatives(t, state_vector): returns [dy/dt]
         """
-        self.units = units
-        self.state_vars = []
-        self.var_to_unit = {}
+        self.units: List[Any] = units
+        self.state_vars: List[str] = []
+        self.var_to_unit: Dict[str, Any] = {}
         self._build_state_map()
 
-    def _build_state_map(self):
+    def _build_state_map(self) -> None:
         """Maps each state variable to its owning unit."""
         for unit in self.units:
             state = unit.get_state()
@@ -42,7 +44,12 @@ class ODESolver:
             derivatives.update(derivs)
         return derivatives
 
-    def solve(self, t_span: Tuple[float, float], y0: Dict[str, float], t_eval=None):
+    def solve(
+        self,
+        t_span: Tuple[float, float],
+        y0: Dict[str, float],
+        t_eval: Optional[List[float]] = None,
+    ) -> List[Dict[str, Any]]:
       """Integrate the system using a simple Euler method."""
 
       if t_eval is None:

--- a/hdt/inputs/input_parser.py
+++ b/hdt/inputs/input_parser.py
@@ -1,21 +1,24 @@
+from __future__ import annotations
+
 import json
 import math
+from typing import Any, Dict, Union
 from utils.logging_utils import setup_logger
 
 logger = setup_logger(__name__)
 
 class InputParser:
-    def __init__(self, mapping_path: str):
+    def __init__(self, mapping_path: str) -> None:
         """
         Initialize the InputParser with a wearable-to-model mapping.
 
         Args:
             mapping_path (str): Path to wearable_mapping.json
         """
-        with open(mapping_path, 'r') as file:
-            self.mapping = json.load(file)
+        with open(mapping_path, "r") as file:
+            self.mapping: Dict[str, list[str]] = json.load(file)
 
-    def parse(self, raw_data) -> dict:
+    def parse(self, raw_data: Union[Dict[str, Any], str]) -> Dict[str, Dict[str, Any]]:
         """
        Map incoming raw JSON data to internal physiological modules. ``raw_data``
        may be a dictionary or a path to a JSON file. Any ``None`` values are
@@ -40,10 +43,10 @@ class InputParser:
 
         # Allow passing a file path for convenience
         if isinstance(raw_data, str):
-            with open(raw_data, 'r') as f:
+            with open(raw_data, "r") as f:
                 raw_data = json.load(f)
 
-        parsed_signals = {}
+        parsed_signals: Dict[str, Dict[str, Any]] = {}
 
         for signal, targets in self.mapping.items():
              value = raw_data.get(signal)

--- a/hdt/inputs/signal_normalizer.py
+++ b/hdt/inputs/signal_normalizer.py
@@ -1,17 +1,20 @@
+from __future__ import annotations
+
 import math
+from typing import Any, Dict
 from utils.logging_utils import setup_logger
 
 logger = setup_logger(__name__)
 
 
 class SignalNormalizer:
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Optionally initialize normalization parameters or scaling coefficients.
         """
         pass
 
-    def normalize(self, parsed_signals: dict) -> dict:
+    def normalize(self, parsed_signals: Dict[str, Dict[str, Any]]) -> Dict[str, Dict[str, float]]:
         """
         Normalize all signal values by unit and signal name.
 
@@ -26,7 +29,7 @@ class SignalNormalizer:
         Returns:
             dict: Normalized signals in the same structure
         """
-        normalized_signals = {}
+        normalized_signals: Dict[str, Dict[str, float]] = {}
 
         for unit, signals in parsed_signals.items():
             normalized_signals[unit] = {}

--- a/hdt/simulator.py
+++ b/hdt/simulator.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
 from hdt.engine.simulator import Simulator as _Simulator
 
 DEFAULT_CONFIG = {
@@ -10,11 +14,17 @@ DEFAULT_CONFIG = {
 class Simulator(_Simulator):
     """Convenience wrapper providing a default minimal configuration."""
 
-    def __init__(self, config=None, wearable_inputs=None, use_ode=False, verbose=False):
+    def __init__(
+        self,
+        config: Optional[Dict[str, Any]] = None,
+        wearable_inputs: Optional[Dict[str, Any]] = None,
+        use_ode: bool = False,
+        verbose: bool = False,
+    ) -> None:
         config = config or DEFAULT_CONFIG
         super().__init__(config=config, wearable_inputs=wearable_inputs, use_ode=use_ode, verbose=verbose)
 
-    def inject_signal(self, signal_name: str, value):
+    def inject_signal(self, signal_name: str, value: Any) -> None:
         """Inject a wearable signal value for the next step."""
         self.signals.setdefault('BrainController', {})
         self.signals['BrainController'][signal_name] = value

--- a/hdt/streams/stream.py
+++ b/hdt/streams/stream.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections import deque
 from typing import Any, Deque, List, Tuple
 

--- a/hdt/streams/stream_map.py
+++ b/hdt/streams/stream_map.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import List
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+python_version = 3.11
+strict = True
+ignore_missing_imports = True
+exclude = tests


### PR DESCRIPTION
## Summary
- add mypy.ini with strict settings
- add typing to simulator wrapper and helper modules
- type hint wearable input parsing and normalization
- type hint time manager and solver

## Testing
- `pytest -q`
- `mypy hdt/core hdt/engine hdt/streams hdt/inputs hdt/config_loader.py hdt/simulator.py` *(fails: Function is missing a type annotation)*

------
https://chatgpt.com/codex/tasks/task_e_686230418a0c83329acc41d15765aed2