### PR TITLE
Add type hints across HDT unit operations

### DIFF
--- a/hdt/ingestion/logger.py
+++ b/hdt/ingestion/logger.py
@@ -5,7 +5,7 @@ from datetime import datetime
 HISTORY_PATH = "data/health_history.json"
 
 
-def log_health_snapshot(raw_data: dict, sim_result: dict):
+def log_health_snapshot(raw_data: dict, sim_result: dict) -> None:
     """
     Appends a new health + simulation record to the history log.
     """

--- a/hdt/unit_operations/base_unit.py
+++ b/hdt/unit_operations/base_unit.py
@@ -1,29 +1,30 @@
 from abc import ABC, abstractmethod
+from typing import Any, Dict
 
 
 class BaseUnit(ABC):
     """Abstract base class for all unit operations."""
 
     @abstractmethod
-    def step(self, inputs):
+    def step(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """Execute one simulation step using ``inputs``."""
         raise NotImplementedError
 
     @abstractmethod
-    def reset(self):
+    def reset(self) -> None:
         """Reset internal state to initial values."""
         raise NotImplementedError
 
     @abstractmethod
-    def get_state(self):
+    def get_state(self) -> Dict[str, Any]:
         """Return a dictionary representing the current state."""
         raise NotImplementedError
 
     @abstractmethod
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, Any]) -> None:
         """Set the internal state from ``state_dict``."""
         raise NotImplementedError
 
-    def derivatives(self, t, state_dict):
+    def derivatives(self, t: float, state_dict: Dict[str, float]) -> Dict[str, float]:
         """Return time derivatives for ODE based simulation."""
         raise NotImplementedError("This unit does not implement ODE dynamics")

--- a/hdt/unit_operations/brain_controller.py
+++ b/hdt/unit_operations/brain_controller.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict, Optional
+
 from .base_unit import BaseUnit
 
 
 class BrainController(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """Central logic hub for hormonal and behavioral control."""
 
         self.cortisol_threshold = config.get("cortisol_threshold", 0.65)
@@ -18,7 +20,7 @@ class BrainController(BaseUnit):
         # Optional output overrides
         self._override = {}
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset internal controller state."""
         self.stress_level = 0.0
         self.hunger_level = 0.5
@@ -27,8 +29,12 @@ class BrainController(BaseUnit):
         self._override = {}
 
     def integrate_inputs(
-        self, muscle_signals, gut_signals, wearable_signals, time_of_day
-    ):
+        self,
+        muscle_signals: Dict[str, Any],
+        gut_signals: Dict[str, Any],
+        wearable_signals: Dict[str, Any],
+        time_of_day: int,
+    ) -> Dict[str, float]:
         """
         Combines physiological inputs and wearable data into control outputs.
 
@@ -92,7 +98,7 @@ class BrainController(BaseUnit):
 
         return signals
 
-    def apply_priority_rules(self, signals):
+    def apply_priority_rules(self, signals: Dict[str, float]) -> Dict[str, float]:
         """
         Applies hardcoded priority rules for control logic.
         """
@@ -107,7 +113,11 @@ class BrainController(BaseUnit):
 
     # ------------------------------------------------------------------
     # New control routing logic
-    def route_control_signals(self, wearable_signals, metabolic_state):
+    def route_control_signals(
+        self,
+        wearable_signals: Dict[str, Any],
+        metabolic_state: Dict[str, Any],
+    ) -> Dict[str, Any]:
         """Process wearable and metabolic inputs into control outputs."""
         stress_score = wearable_signals.get("stress_score", 0.0)
         sleep_score = wearable_signals.get("sleep_score", 0.8)
@@ -148,11 +158,11 @@ class BrainController(BaseUnit):
 
         return outputs
 
-    def inject_override(self, override_dict):
+    def inject_override(self, override_dict: Optional[Dict[str, Any]]) -> None:
         """Override output signals in ``route_control_signals``."""
         self._override = override_dict or {}
 
-    def get_state(self):
+    def get_state(self) -> Dict[str, Any]:
         return {
             "stress_level": self.stress_level,
             "hunger_level": self.hunger_level,
@@ -160,13 +170,13 @@ class BrainController(BaseUnit):
             "time_of_day": self.time_of_day,
         }
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, Any]) -> None:
         self.stress_level = state_dict.get("stress_level", self.stress_level)
         self.hunger_level = state_dict.get("hunger_level", self.hunger_level)
         self.sleep_pressure = state_dict.get("sleep_pressure", self.sleep_pressure)
         self.time_of_day = state_dict.get("time_of_day", self.time_of_day)
 
-    def set_manual_override(self, state_name, value):
+    def set_manual_override(self, state_name: str, value: Any) -> None:
         """
         Manually override internal states like stress_level or time_of_day.
         """
@@ -175,12 +185,12 @@ class BrainController(BaseUnit):
 
     def step(
         self,
-        muscle_signals=None,
-        gut_signals=None,
-        wearable_signals=None,
-        time_of_day=None,
-        metabolic_state=None,
-    ):
+        muscle_signals: Optional[Dict[str, Any]] = None,
+        gut_signals: Optional[Dict[str, Any]] = None,
+        wearable_signals: Optional[Dict[str, Any]] = None,
+        time_of_day: Optional[int] = None,
+        metabolic_state: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Execute one control step.
 
         This keeps backward compatibility with the original signature while also

--- a/hdt/unit_operations/colon_microbiome_reactor.py
+++ b/hdt/unit_operations/colon_microbiome_reactor.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict
+
 from .base_unit import BaseUnit
 
 
 class ColonMicrobiomeReactor(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """
         Simulates fiber fermentation, short-chain fatty acid (SCFA) production,
         and gut-brain signaling via microbiome.
@@ -20,17 +22,17 @@ class ColonMicrobiomeReactor(BaseUnit):
         )
         self.transit_time = config.get("transit_time", 480)  # 8 hours
 
-    def reset(self):
+    def reset(self) -> None:
         """No persistent state to reset."""
         pass
 
-    def get_state(self):
+    def get_state(self) -> Dict[str, Any]:
         return {}
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, Any]) -> None:
         pass
 
-    def process_residue(self, fiber_input):
+    def process_residue(self, fiber_input: float) -> Dict[str, Any]:
         """
         Ferments unabsorbed fiber to produce SCFAs and waste.
 
@@ -62,7 +64,7 @@ class ColonMicrobiomeReactor(BaseUnit):
             "gut_brain_signals": gut_signals,
         }
 
-    def step(self, fiber_input):
+    def step(self, fiber_input: float) -> Dict[str, Any]:
         """
         Wrapper for process_residue to maintain consistent unit operation API.
         """

--- a/hdt/unit_operations/gut_reactor.py
+++ b/hdt/unit_operations/gut_reactor.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict, Optional
+
 from .base_unit import BaseUnit
 
 
 class GutReactor(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """
         Simulates gastrointestinal processing of ingested food using ODEs or static digestion.
 
@@ -26,14 +28,18 @@ class GutReactor(BaseUnit):
         # Optional override for real-time control via the simulator
         self.override_inputs = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset internal nutrient pools."""
         self.glucose = 0.0
         self.fatty_acids = 0.0
         self.amino_acids = 0.0
         self.water = 0.0
 
-    def load_meal(self, meal_input, hormones=None):
+    def load_meal(
+        self,
+        meal_input: Dict[str, float],
+        hormones: Optional[Dict[str, float]] = None,
+    ) -> None:
         """
         Loads a meal into the gut for continuous simulation.
         """
@@ -48,7 +54,7 @@ class GutReactor(BaseUnit):
         self.water = meal_input.get("water", 0.0) * digestion_eff
         # Fiber remains residue — not modeled here
 
-    def get_state(self):
+    def get_state(self) -> Dict[str, float]:
         return {
             "gut_glucose": self.glucose,
             "gut_fatty_acids": self.fatty_acids,
@@ -56,17 +62,17 @@ class GutReactor(BaseUnit):
             "gut_water": self.water,
         }
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, float]) -> None:
         self.glucose = state_dict["gut_glucose"]
         self.fatty_acids = state_dict["gut_fatty_acids"]
         self.amino_acids = state_dict["gut_amino_acids"]
         self.water = state_dict["gut_water"]
 
-    def inject_override(self, inputs: dict):
+    def inject_override(self, inputs: Dict[str, Any]) -> None:
         """Store override inputs to be used on the next :meth:`step` call."""
         self.override_inputs = inputs
 
-    def derivatives(self, t, state):
+    def derivatives(self, t: float, state: Dict[str, float]) -> Dict[str, float]:
         """
         Simulates continuous absorption using first-order kinetics.
         dX/dt = -k * X
@@ -80,7 +86,12 @@ class GutReactor(BaseUnit):
             "gut_water": -k * state["gut_water"],
         }
 
-    def digest(self, meal_input, duration_min=60, hormones=None):
+    def digest(
+        self,
+        meal_input: Dict[str, float],
+        duration_min: int = 60,
+        hormones: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Dict[str, float]]:
         """
         Static digestion for backward compatibility or simple use.
         """
@@ -121,7 +132,12 @@ class GutReactor(BaseUnit):
 
         return {"absorbed": absorbed, "residue": residue}
 
-    def step(self, meal_input, duration_min=60, hormones=None):
+    def step(
+        self,
+        meal_input: Dict[str, float],
+        duration_min: int = 60,
+        hormones: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Dict[str, float]]:
         if self.override_inputs is not None:
             o = self.override_inputs
             meal_input = o.get("meal_input", meal_input)

--- a/hdt/unit_operations/heart_circulation.py
+++ b/hdt/unit_operations/heart_circulation.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict
+
 from .base_unit import BaseUnit
 
 
 class HeartCirculation(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """Cardiovascular transport of nutrients and hormones.
 
         Parameters
@@ -32,7 +34,7 @@ class HeartCirculation(BaseUnit):
             "water": 0.0,
         }
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset nutrient pools and absorbed inputs."""
         self.cv_glucose = 0.0
         self.cv_fatty_acids = 0.0
@@ -45,7 +47,7 @@ class HeartCirculation(BaseUnit):
             "water": 0.0,
         }
 
-    def distribute(self, absorbed_nutrients):
+    def distribute(self, absorbed_nutrients: Dict[str, float]) -> Dict[str, Any]:
         """Route nutrients from gut to liver and systemic tissues.
 
         Parameters
@@ -75,14 +77,14 @@ class HeartCirculation(BaseUnit):
             "delay_minutes": self.transport_delay,
         }
 
-    def step(self, absorbed_nutrients):
+    def step(self, absorbed_nutrients: Dict[str, float]) -> Dict[str, Any]:
         """Wrapper for :meth:`distribute` for unit operation API."""
         return self.distribute(absorbed_nutrients)
 
     # ------------------------------------------------------------------
     # ODE integration helpers
     # ------------------------------------------------------------------
-    def get_state(self):
+    def get_state(self) -> Dict[str, float]:
         """Return the current amounts of nutrients in transit."""
         return {
             "cv_glucose": self.cv_glucose,
@@ -91,14 +93,14 @@ class HeartCirculation(BaseUnit):
             "cv_water": self.cv_water,
         }
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, float]) -> None:
         """Set the internal state from ``state_dict``."""
         self.cv_glucose = state_dict["cv_glucose"]
         self.cv_fatty_acids = state_dict["cv_fatty_acids"]
         self.cv_amino_acids = state_dict["cv_amino_acids"]
         self.cv_water = state_dict["cv_water"]
 
-    def derivatives(self, t, state):
+    def derivatives(self, t: float, state: Dict[str, float]) -> Dict[str, float]:
         """First-order delay dynamics for nutrient transport."""
         return {
             "cv_glucose": self._absorbed.get("glucose", 0.0)

--- a/hdt/unit_operations/hormone_router.py
+++ b/hdt/unit_operations/hormone_router.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict, List, Optional
+
 from .base_unit import BaseUnit
 
 
 class HormoneRouter(BaseUnit):
-    def __init__(self, dominance_rules=None):
+    def __init__(self, dominance_rules: Optional[Dict[str, List[str]]] = None) -> None:
         """
         Modulates hormone signals by enforcing dominance rules.
 
@@ -15,17 +17,17 @@ class HormoneRouter(BaseUnit):
             "glucagon": ["insulin"],
         }
 
-    def reset(self):
+    def reset(self) -> None:
         """No dynamic state to reset."""
         pass
 
-    def get_state(self):
+    def get_state(self) -> Dict[str, Any]:
         return {}
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, Any]) -> None:
         pass
 
-    def resolve(self, hormone_outputs):
+    def resolve(self, hormone_outputs: Dict[str, float]) -> Dict[str, float]:
         """
         Adjust hormone signals based on dominance suppression logic.
 
@@ -48,7 +50,7 @@ class HormoneRouter(BaseUnit):
         # ------------------------------------------------------------------
 
     # New routing interface
-    def route(self, hormone_candidates):
+    def route(self, hormone_candidates: Dict[str, float]) -> Dict[str, float]:
         """Resolve dominance for a set of hormone candidates.
 
         Parameters
@@ -65,7 +67,7 @@ class HormoneRouter(BaseUnit):
         adjusted = self.resolve(hormone_candidates)
         return {k: round(v, 3) for k, v in adjusted.items()}
 
-    def step(self, hormone_outputs):
+    def step(self, hormone_outputs: Dict[str, float]) -> Dict[str, float]:
         """
         Step method to fit simulation loop.
 

--- a/hdt/unit_operations/kidney_reactor.py
+++ b/hdt/unit_operations/kidney_reactor.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict
+
 from .base_unit import BaseUnit
 
 
 class KidneyReactor(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """
         Simulates renal filtration and excretion of urea, water, and electrolytes.
 
@@ -15,17 +17,19 @@ class KidneyReactor(BaseUnit):
         self.urea_clearance = config.get("urea_clearance", 55)  # mL/min
         self.fluid_reabsorption = config.get("fluid_reabsorption", 0.96)
 
-    def reset(self):
+    def reset(self) -> None:
         """No internal state to reset for now."""
         pass
 
-    def get_state(self):
+    def get_state(self) -> Dict[str, Any]:
         return {}
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, Any]) -> None:
         pass
 
-    def filter(self, blood_input, duration_min=60):
+    def filter(
+        self, blood_input: Dict[str, float], duration_min: int = 60
+    ) -> Dict[str, Dict[str, float]]:
         """
         Filters blood for urea and water removal.
 
@@ -66,7 +70,7 @@ class KidneyReactor(BaseUnit):
             "retained": {"urea": retained_urea, "water": retained_water},
         }
 
-    def step(self, blood_input, duration_min=60):
+    def step(self, blood_input: Dict[str, float], duration_min: int = 60) -> Dict[str, Dict[str, float]]:
         """
         Wrapper to standardize simulation interface.
 

--- a/hdt/unit_operations/liver_metabolic_router.py
+++ b/hdt/unit_operations/liver_metabolic_router.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict, Optional
+
 from .base_unit import BaseUnit
 
 
 class LiverMetabolicRouter(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """
         Liver router that handles nutrient processing, storage, and mobilization.
 
@@ -31,7 +33,7 @@ class LiverMetabolicRouter(BaseUnit):
         # Optional override for real-time control
         self.override_inputs = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset internal liver state."""
         self.liver_glucose = 0.0
         self.current_glycogen = 0.0
@@ -39,7 +41,9 @@ class LiverMetabolicRouter(BaseUnit):
         self._insulin = 0.5
         self._glucagon = 0.5
 
-    def load_portal_input(self, portal_input, signals=None):
+    def load_portal_input(
+        self, portal_input: Dict[str, float], signals: Optional[Dict[str, float]] = None
+    ) -> None:
         """
         Used for continuous simulation: sets incoming glucose & hormone levels.
         """
@@ -48,21 +52,21 @@ class LiverMetabolicRouter(BaseUnit):
         self._insulin = signals.get("insulin", 0.5)
         self._glucagon = signals.get("glucagon", 0.5)
 
-    def get_state(self):
+    def get_state(self) -> Dict[str, float]:
         return {
             "liver_glucose": self.liver_glucose,
             "liver_glycogen": self.current_glycogen,
         }
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, float]) -> None:
         self.liver_glucose = state_dict["liver_glucose"]
         self.current_glycogen = state_dict["liver_glycogen"]
 
-    def inject_override(self, inputs: dict):
+    def inject_override(self, inputs: Dict[str, Any]) -> None:
         """Store override inputs to be used on the next :meth:`step` call."""
         self.override_inputs = inputs
 
-    def derivatives(self, t, state):
+    def derivatives(self, t: float, state: Dict[str, float]) -> Dict[str, float]:
         """
         ODE model: glucose from gut is stored as glycogen based on insulin levels.
         """
@@ -86,8 +90,12 @@ class LiverMetabolicRouter(BaseUnit):
         return {"liver_glucose": d_glucose_dt, "liver_glycogen": d_glycogen_dt}
 
     def route(
-        self, portal_input, microbiome_input=None, mobilized_reserves=None, signals=None
-    ):
+        self,
+        portal_input: Dict[str, float],
+        microbiome_input: Optional[Dict[str, float]] = None,
+        mobilized_reserves: Optional[Dict[str, float]] = None,
+        signals: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Any]:
         """
         Static / discrete logic version of liver routing.
         """
@@ -136,8 +144,12 @@ class LiverMetabolicRouter(BaseUnit):
         }
 
     def step(
-        self, portal_input, microbiome_input=None, mobilized_reserves=None, signals=None
-    ):
+        self,
+        portal_input: Dict[str, float],
+        microbiome_input: Optional[Dict[str, float]] = None,
+        mobilized_reserves: Optional[Dict[str, float]] = None,
+        signals: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Any]:
         if self.override_inputs is not None:
             o = self.override_inputs
             portal_input = o.get("portal_input", portal_input)

--- a/hdt/unit_operations/lung_reactor.py
+++ b/hdt/unit_operations/lung_reactor.py
@@ -1,8 +1,15 @@
+from typing import Any, Dict, Optional
+
 from .base_unit import BaseUnit
 
 
 class LungReactor(BaseUnit):
-    def __init__(self, config=None, oxygen_uptake_rate=320, co2_exhale_rate=250):
+    def __init__(
+        self,
+        config: Optional[Dict[str, Any]] = None,
+        oxygen_uptake_rate: float = 320,
+        co2_exhale_rate: float = 250,
+    ) -> None:
         """Simulate lung gas exchange for oxygen uptake and CO₂ removal.
 
         Parameters
@@ -29,12 +36,12 @@ class LungReactor(BaseUnit):
         # Optional override for real-time control
         self.override_inputs = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset accumulated CO₂ pool."""
         self.co2_pool = 0.0
         self._co2_in_rate = 0.0
 
-    def exchange(self, duration_min=1, co2_in=0):
+    def exchange(self, duration_min: int = 1, co2_in: float = 0.0) -> Dict[str, float]:
         """Perform discrete gas exchange for a given time step."""
 
         self.co2_pool += co2_in
@@ -51,7 +58,7 @@ class LungReactor(BaseUnit):
             "co2_remaining": self.co2_pool,
         }
 
-    def step(self, duration_min=1, co2_in=0):
+    def step(self, duration_min: int = 1, co2_in: float = 0.0) -> Dict[str, float]:
         """
         Execute one simulation step for the lungs.
 
@@ -68,17 +75,17 @@ class LungReactor(BaseUnit):
 
     # ------------------------------------------------------------------
     # ODE compatibility methods
-    def get_state(self):
+    def get_state(self) -> Dict[str, float]:
         return {"lung_co2": self.co2_pool}
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, float]) -> None:
         self.co2_pool = state_dict["lung_co2"]
 
-    def inject_override(self, inputs: dict):
+    def inject_override(self, inputs: Dict[str, Any]) -> None:
         """Store override inputs to be used on the next :meth:`step` call."""
         self.override_inputs = inputs
 
-    def derivatives(self, t, state):
+    def derivatives(self, t: float, state: Dict[str, float]) -> Dict[str, float]:
         """Rate of change of CO₂ in the lung pool."""
         co2_pool = state["lung_co2"]
         exhale = min(self.co2_exhale_rate, co2_pool)

--- a/hdt/unit_operations/muscle_effector.py
+++ b/hdt/unit_operations/muscle_effector.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict, Optional
+
 from .base_unit import BaseUnit
 
 
 class MuscleEffector(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """
         Simulates energy usage in muscle based on physical activity and hormone influence.
         """
@@ -20,7 +22,7 @@ class MuscleEffector(BaseUnit):
         # Optional override for simulator injections
         self.override_inputs = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset internal substrate pools and settings."""
         self.glucose = 0.0
         self.fat = 0.0
@@ -28,7 +30,12 @@ class MuscleEffector(BaseUnit):
         self.activity_level = "rest"
         self.hormones = {"insulin": 0.6, "cortisol": 0.2}
 
-    def load_inputs(self, substrate_pool, activity_level="rest", hormones=None):
+    def load_inputs(
+        self,
+        substrate_pool: Dict[str, float],
+        activity_level: str = "rest",
+        hormones: Optional[Dict[str, float]] = None,
+    ) -> None:
         """
         Sets internal fuel stores (glucose, fat, ketones) and external influences.
         """
@@ -38,23 +45,23 @@ class MuscleEffector(BaseUnit):
         self.activity_level = activity_level
         self.hormones = hormones or {"insulin": 0.6, "cortisol": 0.2}
 
-    def get_state(self):
+    def get_state(self) -> Dict[str, float]:
         return {
             "muscle_glucose": self.glucose,
             "muscle_fat": self.fat,
             "muscle_ketones": self.ketones,
         }
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, float]) -> None:
         self.glucose = state_dict["muscle_glucose"]
         self.fat = state_dict["muscle_fat"]
         self.ketones = state_dict["muscle_ketones"]
 
-    def inject_override(self, inputs: dict):
+    def inject_override(self, inputs: Dict[str, Any]) -> None:
         """Store override inputs to be used on the next :meth:`step` call."""
         self.override_inputs = inputs
 
-    def derivatives(self, t, state):
+    def derivatives(self, t: float, state: Dict[str, float]) -> Dict[str, float]:
         """
         Calculates substrate usage rates based on current state and hormones.
         """
@@ -82,7 +89,13 @@ class MuscleEffector(BaseUnit):
             "muscle_ketones": -ketone_use,
         }
 
-    def step(self, inputs, activity_level="rest", duration_min=60, hormones=None):
+    def step(
+        self,
+        inputs: Dict[str, float],
+        activity_level: str = "rest",
+        duration_min: int = 60,
+        hormones: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Any]:
         if self.override_inputs is not None:
             o = self.override_inputs
             inputs = o.get("inputs", inputs)
@@ -93,7 +106,13 @@ class MuscleEffector(BaseUnit):
 
         return self.metabolize(inputs, activity_level, duration_min, hormones)
 
-    def metabolize(self, inputs, activity_level="rest", duration_min=60, hormones=None):
+    def metabolize(
+        self,
+        inputs: Dict[str, float],
+        activity_level: str = "rest",
+        duration_min: int = 60,
+        hormones: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Any]:
         """
         Optional discrete simulation mode (unchanged).
         """

--- a/hdt/unit_operations/pancreatic_valve.py
+++ b/hdt/unit_operations/pancreatic_valve.py
@@ -1,8 +1,10 @@
+from typing import Any, Dict
+
 from .base_unit import BaseUnit
 
 
 class PancreaticValve(BaseUnit):
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """
         Simulates insulin/glucagon release in response to blood glucose.
 
@@ -26,14 +28,16 @@ class PancreaticValve(BaseUnit):
         # Optional override for real-time control
         self.override_inputs = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset hormone levels and cached inputs."""
         self.insulin_level = 0.5
         self.glucagon_level = 0.5
         self._blood_glucose = self.insulin_threshold
         self._rate_of_change = 0.0
 
-    def regulate(self, blood_glucose_mmol_per_L, rate_of_change=0.0):
+    def regulate(
+        self, blood_glucose_mmol_per_L: float, rate_of_change: float = 0.0
+    ) -> Dict[str, float]:
         """
         Releases insulin or glucagon based on glucose level and change.
 
@@ -65,12 +69,12 @@ class PancreaticValve(BaseUnit):
 
         return {"insulin": round(insulin, 3), "glucagon": round(glucagon, 3)}
 
-    def load_inputs(self, blood_glucose, rate_of_change=0.0):
+    def load_inputs(self, blood_glucose: float, rate_of_change: float = 0.0) -> None:
         """Store inputs for use in derivatives."""
         self._blood_glucose = blood_glucose
         self._rate_of_change = rate_of_change
 
-    def step(self, glucose, rate_of_change=0.0):
+    def step(self, glucose: float, rate_of_change: float = 0.0) -> Dict[str, float]:
         """
         Executes one simulation step for hormone regulation.
 
@@ -95,21 +99,21 @@ class PancreaticValve(BaseUnit):
 
     # ------------------------------------------------------------------
     # ODE-compatible methods
-    def get_state(self):
+    def get_state(self) -> Dict[str, float]:
         return {
             "pancreatic_insulin": self.insulin_level,
             "pancreatic_glucagon": self.glucagon_level,
         }
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, float]) -> None:
         self.insulin_level = state_dict["pancreatic_insulin"]
         self.glucagon_level = state_dict["pancreatic_glucagon"]
 
-    def inject_override(self, inputs: dict):
+    def inject_override(self, inputs: Dict[str, Any]) -> None:
         """Store override inputs to be used on the next :meth:`step` call."""
         self.override_inputs = inputs
 
-    def derivatives(self, t, state):
+    def derivatives(self, t: float, state: Dict[str, float]) -> Dict[str, float]:
         """Simple first-order approach toward regulated hormone levels."""
         target = self.regulate(self._blood_glucose, self._rate_of_change)
         d_insulin = target["insulin"] - state["pancreatic_insulin"]

--- a/hdt/unit_operations/skin_thermoregulator.py
+++ b/hdt/unit_operations/skin_thermoregulator.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Optional
+
 from .base_unit import BaseUnit
 
 
@@ -10,7 +12,7 @@ class SkinThermoregulator(BaseUnit):
     existing simulator and tests.
     """
 
-    def __init__(self, config):
+    def __init__(self, config: Dict[str, Any]) -> None:
         """Initialize the regulator with optional tuning parameters."""
 
         # Maximum achievable sweat rate in L/hr
@@ -39,7 +41,7 @@ class SkinThermoregulator(BaseUnit):
         # Optional override for real-time control
         self.override_inputs = None
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset cumulative sweat and heat loss."""
         self.total_sweat = 0.0
         self.total_heat_loss = 0.0
@@ -49,7 +51,13 @@ class SkinThermoregulator(BaseUnit):
 
     # ------------------------------------------------------------------
     # Discrete helper used by the simulator
-    def regulate(self, core_temp, ambient_temp, duration_hr=1.0, hormones=None):
+    def regulate(
+        self,
+        core_temp: float,
+        ambient_temp: float,
+        duration_hr: float = 1.0,
+        hormones: Optional[Dict[str, float]] = None,
+    ) -> Dict[str, Any]:
         """Backward compatible wrapper around :meth:`step`."""
 
         cortisol = hormones.get("cortisol", 0.0) if hormones else 0.0
@@ -66,7 +74,13 @@ class SkinThermoregulator(BaseUnit):
         }
 
     # ------------------------------------------------------------------
-    def step(self, core_temp, ambient_temp, cortisol=0.0, duration_hr=1.0):
+    def step(
+        self,
+        core_temp: float,
+        ambient_temp: float,
+        cortisol: float = 0.0,
+        duration_hr: float = 1.0,
+    ) -> Dict[str, float]:
         """Execute a discrete thermoregulation step.
 
         Parameters
@@ -119,21 +133,21 @@ class SkinThermoregulator(BaseUnit):
 
     # ------------------------------------------------------------------
     # ODE compatibility methods
-    def get_state(self):
+    def get_state(self) -> Dict[str, float]:
         return {
             "skin_sweat_total": self.total_sweat,
             "skin_heat_loss_total": self.total_heat_loss,
         }
 
-    def set_state(self, state_dict):
+    def set_state(self, state_dict: Dict[str, float]) -> None:
         self.total_sweat = state_dict["skin_sweat_total"]
         self.total_heat_loss = state_dict["skin_heat_loss_total"]
 
-    def inject_override(self, inputs: dict):
+    def inject_override(self, inputs: Dict[str, Any]) -> None:
         """Store override inputs to be used on the next :meth:`step` call."""
         self.override_inputs = inputs
 
-    def derivatives(self, t, state):
+    def derivatives(self, t: float, state: Dict[str, float]) -> Dict[str, float]:
         """Derivatives for ODE integration of cumulative values."""
 
         core_temp = self._core_temp


### PR DESCRIPTION
## Summary
- add explicit typing to BaseUnit abstract methods
- type annotations for helper function `log_health_snapshot`
- annotate unit operation modules to satisfy type checking

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68623918be7483328c28b933705e0e26