### PR TITLE
Fix module shadowing

### DIFF
--- a/calibrate_model.py
+++ b/calibrate_model.py
@@ -2,9 +2,9 @@ import json
 from pathlib import Path
 
 try:  # pragma: no cover - optional dependency
-    import matplotlib.pyplot as plt
+    import matplotlib.pyplot as plt_module
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
-    plt = None
+    plt_module = None
 
 from typing import Any, Dict, List
 
@@ -26,7 +26,7 @@ def create_plots(
         output_path (Path): location to save the image.
     """
 
-    if plt is None:
+    if plt_module is None:
         # Matplotlib not available; skip plotting
         return
     
@@ -34,7 +34,7 @@ def create_plots(
     glycogen_pred = [snap.get("Liver", {}).get("liver_glycogen") for snap in history]
     heart_rate_pred = [heart_rate_input for _ in history]
 
-    fig, axes = plt.subplots(2, 1, figsize=(8, 8))
+    fig, axes = plt_module.subplots(2, 1, figsize=(8, 8))
 
     # Predicted vs baseline values
     axes[0].plot(minutes, glycogen_pred, label="predicted_liver_glycogen")
@@ -69,7 +69,7 @@ def create_plots(
 
     fig.tight_layout()
     fig.savefig(output_path)
-    plt.close(fig)
+    plt_module.close(fig)
 
 def run_calibration(save_logs: bool = True) -> Dict[str, Any]:
     """Run a single calibration step and optionally save logs."""

--- a/hdt/config_loader.py
+++ b/hdt/config_loader.py
@@ -4,8 +4,9 @@ from typing import Any, Dict, List, Tuple, cast
 
 try:
     import yaml  # type: ignore
+    yaml_lib = yaml
 except ModuleNotFoundError:  # pragma: no cover - optional dependency may be absent
-    yaml = None
+    yaml_lib = None
 
 
 def _parse_scalar(value: str) -> Any:
@@ -73,15 +74,15 @@ def _simple_yaml_load(path: str) -> Dict[str, Any]:
 
 def load_units_config(path: str) -> Dict[str, Any]:
     """Load unit configuration YAML."""
-    if yaml is not None:
+    if yaml_lib is not None:
         with open(path, "r", encoding="utf-8") as f:
-            return cast(Dict[str, Any], yaml.safe_load(f))
+            return cast(Dict[str, Any], yaml_lib.safe_load(f))
     return _simple_yaml_load(path)
 
 
 def load_sim_params(path: str) -> Dict[str, Any]:
     """Load simulator parameter YAML."""
-    if yaml is not None:
+    if yaml_lib is not None:
         with open(path, "r", encoding="utf-8") as f:
-            return cast(Dict[str, Any], yaml.safe_load(f))
+            return cast(Dict[str, Any], yaml_lib.safe_load(f))
     return _simple_yaml_load(path)

--- a/hdt/recommender/recommender.py
+++ b/hdt/recommender/recommender.py
@@ -1,7 +1,8 @@
 try:
     import yaml  # type: ignore
+    yaml_lib = yaml
 except ModuleNotFoundError:  # pragma: no cover
-    yaml = None
+    yaml_lib = None
 
 from typing import Any, Dict, List, Union
 
@@ -69,10 +70,10 @@ class Recommender:
     def __init__(self, rules_path: str, rule_version: str | None = None) -> None:
         self.rule_version = rule_version
 
-        if yaml is not None:
+        if yaml_lib is not None:
             with open(rules_path, "r", encoding="utf-8") as f:
                 data: Union[List[Dict[str, Any]], Dict[str, List[Dict[str, Any]]]] = (
-                    yaml.safe_load(f) or {}
+                    yaml_lib.safe_load(f) or {}
                 )
         else:
             data = _simple_rules_load(rules_path)
@@ -122,9 +123,9 @@ class Recommender:
 
 def threshold_rule_match(values: Dict[str, float], rules_path: str) -> List[str]:
     """Return recommendations based on numeric threshold rules."""
-    if yaml is not None:
+    if yaml_lib is not None:
         with open(rules_path, "r", encoding="utf-8") as f:
-            rules = yaml.safe_load(f) or {}
+            rules = yaml_lib.safe_load(f) or {}
     else:
         from hdt.config_loader import _simple_yaml_load
 

--- a/utils/config_loader.py
+++ b/utils/config_loader.py
@@ -5,8 +5,9 @@ import os
 
 try:
     import yaml  # type: ignore
+    yaml_lib = yaml
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
-    yaml = None
+    yaml_lib = None
 
 
 def load_baseline_state(path: str = "data/baseline_states.yaml") -> Dict[str, Any]:
@@ -25,9 +26,9 @@ def load_baseline_state(path: str = "data/baseline_states.yaml") -> Dict[str, An
     if not os.path.exists(path):
         return {}
 
-    if yaml is not None:
+    if yaml_lib is not None:
         with open(path, "r", encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
+            return yaml_lib.safe_load(f) or {}
 
     from hdt.config_loader import _simple_yaml_load
 


### PR DESCRIPTION
## Summary
- avoid shadowing matplotlib's pyplot module in `calibrate_model.py`
- avoid shadowing optional yaml dependency in configuration utilities and recommender

## Testing
- `python -m mypy calibrate_model.py hdt utils/config_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686244abbd948332953152f6fc9fb224