### PR TITLE
Clean HDT python modules

### DIFF
--- a/hdt/cli.py
+++ b/hdt/cli.py
@@ -1,3 +1,5 @@
+"""Command line interface for running HDT simulations."""
+
 import argparse
 import json
 from pathlib import Path

--- a/hdt/config_loader.py
+++ b/hdt/config_loader.py
@@ -1,3 +1,5 @@
+"""Utility functions to load YAML configuration files for the simulator."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, List, Tuple, cast

--- a/hdt/core/time_manager.py
+++ b/hdt/core/time_manager.py
@@ -1,3 +1,5 @@
+"""Simple utility to track simulation time in minutes, hours, and days."""
+
 from __future__ import annotations
 
 from typing import Dict

--- a/hdt/engine/__init__.py
+++ b/hdt/engine/__init__.py
@@ -1,0 +1,2 @@
+"""Simulation engine components for the Human Digital Twin."""
+

--- a/hdt/engine/run_simulator.py
+++ b/hdt/engine/run_simulator.py
@@ -1,3 +1,5 @@
+"""Helper to load configuration and run a simulation instance."""
+
 from __future__ import annotations
 
 import json

--- a/hdt/engine/simulator.py
+++ b/hdt/engine/simulator.py
@@ -1,3 +1,5 @@
+"""Main simulator coordinating all unit operations and time progression."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/hdt/engine/solver.py
+++ b/hdt/engine/solver.py
@@ -1,3 +1,5 @@
+"""Very small Euler-based ODE solver used for optional dynamics."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple

--- a/hdt/ingestion/logger.py
+++ b/hdt/ingestion/logger.py
@@ -1,3 +1,5 @@
+"""Simple JSON logging utilities for ingestion examples."""
+
 import json
 import os
 from datetime import datetime
@@ -17,10 +19,10 @@ def log_health_snapshot(raw_data: Dict[str, Any], sim_result: Dict[str, Any]) ->
     }
 
     if not os.path.exists(HISTORY_PATH):
-        with open(HISTORY_PATH, "w") as f:
+        with open(HISTORY_PATH, "w", encoding="utf-8") as f:
             json.dump([entry], f, indent=2)
     else:
-        with open(HISTORY_PATH, "r+") as f:
+        with open(HISTORY_PATH, "r+", encoding="utf-8") as f:
             data = json.load(f)
             data.append(entry)
             f.seek(0)

--- a/hdt/inputs/__init__.py
+++ b/hdt/inputs/__init__.py
@@ -1,0 +1,2 @@
+"""Input utilities for parsing and normalizing wearable data."""
+

--- a/hdt/inputs/input_parser.py
+++ b/hdt/inputs/input_parser.py
@@ -1,3 +1,5 @@
+"""Parses raw wearable data into structured signals for the simulator."""
+
 from __future__ import annotations
 
 import json
@@ -17,7 +19,7 @@ class InputParser:
         Args:
             mapping_path (str): Path to wearable_mapping.json
         """
-        with open(mapping_path, "r") as file:
+        with open(mapping_path, "r", encoding="utf-8") as file:
             self.mapping: Dict[str, list[str]] = json.load(file)
 
     def parse(self, raw_data: Union[Dict[str, Any], str]) -> Dict[str, Dict[str, Any]]:
@@ -45,7 +47,7 @@ class InputParser:
 
         # Allow passing a file path for convenience
         if isinstance(raw_data, str):
-            with open(raw_data, "r") as f:
+            with open(raw_data, "r", encoding="utf-8") as f:
                 raw_data = json.load(f)
 
         raw_dict = cast(Dict[str, Any], raw_data)

--- a/hdt/inputs/signal_normalizer.py
+++ b/hdt/inputs/signal_normalizer.py
@@ -1,3 +1,5 @@
+"""Normalize parsed wearable signals for downstream units."""
+
 from __future__ import annotations
 
 import math
@@ -13,7 +15,6 @@ class SignalNormalizer:
         """
         Optionally initialize normalization parameters or scaling coefficients.
         """
-        pass
 
     def normalize(
         self, parsed_signals: Dict[str, Dict[str, Any]]

--- a/hdt/interface/api.py
+++ b/hdt/interface/api.py
@@ -1,3 +1,5 @@
+"""FastAPI application exposing HDT simulation endpoints."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/hdt/interface/streamlit_app.py
+++ b/hdt/interface/streamlit_app.py
@@ -1,6 +1,6 @@
+"""Streamlit web app for interactive Human Digital Twin demos."""
+
 import json
-import os
-import sys
 from pathlib import Path
 
 import matplotlib.pyplot as plt

--- a/hdt/main.py
+++ b/hdt/main.py
@@ -1,0 +1,2 @@
+"""Entry module for future standalone execution."""
+

--- a/hdt/recommender/__init__.py
+++ b/hdt/recommender/__init__.py
@@ -1,0 +1,2 @@
+"""Recommendation engine modules for lifestyle suggestions."""
+

--- a/hdt/recommender/recommender.py
+++ b/hdt/recommender/recommender.py
@@ -1,3 +1,5 @@
+"""Rule-based recommender supporting simple YAML rule sets."""
+
 try:
     import yaml  # type: ignore
     yaml_lib = yaml

--- a/hdt/recommender/rule_engine.py
+++ b/hdt/recommender/rule_engine.py
@@ -1,3 +1,5 @@
+"""High-level interface exposing rule-based or ML recommendations."""
+
 from __future__ import annotations
 
 import random

--- a/hdt/simulator.py
+++ b/hdt/simulator.py
@@ -1,3 +1,5 @@
+"""Lightweight wrapper exposing sensible defaults for the Simulator."""
+
 from __future__ import annotations
 
 from typing import Any, Dict, Optional

--- a/hdt/streams/__init__.py
+++ b/hdt/streams/__init__.py
@@ -1,3 +1,5 @@
+"""Stream classes for nutrient and signal routing."""
+
 from .stream import Stream
 
 __all__ = ["Stream"]

--- a/hdt/streams/stream.py
+++ b/hdt/streams/stream.py
@@ -1,3 +1,5 @@
+"""Data structures for passing information between unit operations."""
+
 from __future__ import annotations
 
 from collections import deque

--- a/hdt/streams/stream_map.py
+++ b/hdt/streams/stream_map.py
@@ -1,3 +1,5 @@
+"""Static map describing connections between unit operations."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/hdt/tools/calibration.py
+++ b/hdt/tools/calibration.py
@@ -1,9 +1,11 @@
+"""Minimal calibration helper used in unit tests."""
+
 from datetime import datetime
 from typing import Dict, Iterable
 
 
 def calibrate(
-    inputs: Iterable[float], observed_outputs: Iterable[float], *, adjust: bool = False
+    inputs: Iterable[float], observed_outputs: Iterable[float], *, _adjust: bool = False
 ) -> Dict[str, float]:
     """Compare predicted outputs to observed values and compute error metrics.
 
@@ -32,13 +34,10 @@ def calibrate(
     rmse = (sum((p - o) ** 2 for p, o in zip(predicted, observed)) / len(diffs)) ** 0.5
 
     log_line = f"{datetime.now().isoformat()}\tMAE={mae:.4f}\tRMSE={rmse:.4f}\n"
-    with open("calibration_log.txt", "a") as log_file:
+    with open("calibration_log.txt", "a", encoding="utf-8") as log_file:
         log_file.write(log_line)
 
-    if adjust:
-        # Placeholder for parameter adjustment logic. In a real implementation
-        # this would update model parameters based on the computed errors.
-        pass
+
 
     return {"mae": mae, "rmse": rmse}
 

--- a/hdt/unit_operations/__init__.py
+++ b/hdt/unit_operations/__init__.py
@@ -1,3 +1,5 @@
+"""Collection of all unit operation classes used in the simulator."""
+
 from .base_unit import BaseUnit
 from .brain_controller import BrainController
 from .colon_microbiome_reactor import ColonMicrobiomeReactor

--- a/hdt/unit_operations/base_unit.py
+++ b/hdt/unit_operations/base_unit.py
@@ -1,3 +1,5 @@
+"""Abstract interface for unit operations used in the simulation."""
+
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 

--- a/hdt/unit_operations/brain_controller.py
+++ b/hdt/unit_operations/brain_controller.py
@@ -1,3 +1,5 @@
+"""Central control unit coordinating hormones and behavior."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/colon_microbiome_reactor.py
+++ b/hdt/unit_operations/colon_microbiome_reactor.py
@@ -1,3 +1,5 @@
+"""Model of fiber fermentation and SCFA production in the colon."""
+
 from typing import Any, Dict
 
 from .base_unit import BaseUnit
@@ -24,13 +26,12 @@ class ColonMicrobiomeReactor(BaseUnit):
 
     def reset(self) -> None:
         """No persistent state to reset."""
-        pass
 
     def get_state(self) -> Dict[str, Any]:
         return {}
 
     def set_state(self, state_dict: Dict[str, Any]) -> None:
-        pass
+        """This unit has no mutable state."""
 
     def process_residue(self, fiber_input: float) -> Dict[str, Any]:
         """

--- a/hdt/unit_operations/fat_storage_reservoir.py
+++ b/hdt/unit_operations/fat_storage_reservoir.py
@@ -1,3 +1,5 @@
+"""ODE-compatible model of glycogen and fat energy storage."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/gut_reactor.py
+++ b/hdt/unit_operations/gut_reactor.py
@@ -1,3 +1,5 @@
+"""Simplified gastrointestinal digestion and absorption model."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/heart_circulation.py
+++ b/hdt/unit_operations/heart_circulation.py
@@ -1,3 +1,5 @@
+"""Simulates cardiovascular distribution of nutrients and waste."""
+
 from typing import Any, Dict
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/hormone_router.py
+++ b/hdt/unit_operations/hormone_router.py
@@ -1,3 +1,5 @@
+"""Resolve dominance relationships between multiple hormone signals."""
+
 from typing import Any, Dict, List, Optional
 
 from .base_unit import BaseUnit
@@ -19,13 +21,12 @@ class HormoneRouter(BaseUnit):
 
     def reset(self) -> None:
         """No dynamic state to reset."""
-        pass
 
     def get_state(self) -> Dict[str, Any]:
         return {}
 
     def set_state(self, state_dict: Dict[str, Any]) -> None:
-        pass
+        """Stateless unit; nothing to set."""
 
     def resolve(self, hormone_outputs: Dict[str, float]) -> Dict[str, float]:
         """

--- a/hdt/unit_operations/kidney_reactor.py
+++ b/hdt/unit_operations/kidney_reactor.py
@@ -1,3 +1,5 @@
+"""Simulates renal filtration and urine production."""
+
 from typing import Any, Dict
 
 from .base_unit import BaseUnit
@@ -19,13 +21,12 @@ class KidneyReactor(BaseUnit):
 
     def reset(self) -> None:
         """No internal state to reset for now."""
-        pass
 
     def get_state(self) -> Dict[str, Any]:
         return {}
 
     def set_state(self, state_dict: Dict[str, Any]) -> None:
-        pass
+        """This unit maintains no persistent state."""
 
     def filter(
         self, blood_input: Dict[str, float], duration_min: int = 60

--- a/hdt/unit_operations/liver_metabolic_router.py
+++ b/hdt/unit_operations/liver_metabolic_router.py
@@ -1,3 +1,5 @@
+"""Routes nutrients through the liver with optional ODE dynamics."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/lung_reactor.py
+++ b/hdt/unit_operations/lung_reactor.py
@@ -1,3 +1,5 @@
+"""Model of lung gas exchange with optional ODE behavior."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/muscle_effector.py
+++ b/hdt/unit_operations/muscle_effector.py
@@ -1,3 +1,5 @@
+"""Represents muscle tissue energy use and byproduct generation."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/pancreatic_valve.py
+++ b/hdt/unit_operations/pancreatic_valve.py
@@ -1,3 +1,5 @@
+"""Simple endocrine pancreas model releasing insulin and glucagon."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/skin_thermoregulator.py
+++ b/hdt/unit_operations/skin_thermoregulator.py
@@ -1,3 +1,5 @@
+"""Models sweat-driven heat dissipation and dry heat loss."""
+
 from typing import Any, Dict, Optional
 
 from .base_unit import BaseUnit

--- a/hdt/unit_operations/sleep_regulation_center.py
+++ b/hdt/unit_operations/sleep_regulation_center.py
@@ -1,3 +1,5 @@
+"""Circadian model producing sleep drive and melatonin release."""
+
 import math
 
 from typing import Any, Dict, Optional

--- a/hdt/validation/_init_.py
+++ b/hdt/validation/_init_.py
@@ -1,0 +1,2 @@
+"""Validation schemas for external data formats."""
+

--- a/hdt/validation/input_schema.py
+++ b/hdt/validation/input_schema.py
@@ -1,3 +1,5 @@
+"""Pydantic models for validating wearable input payloads."""
+
 from typing import Any, Dict, Optional
 
 from pydantic import BaseModel


### PR DESCRIPTION
## Summary
- add module docstrings across `hdt` package
- remove unused imports and placeholder `pass` lines
- ensure file handling uses UTF‑8 encoding
- tidy unused parameters in calibration helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686250308bf48332ba8eed99f14e43e4